### PR TITLE
Updated getEntityRecord doc by using selector instead of dispatch

### DIFF
--- a/docs/explanations/architecture/entities.md
+++ b/docs/explanations/architecture/entities.md
@@ -15,7 +15,7 @@ The editor keeps track of all these modifications and orchestrates the saving of
 To be able to edit an entity, you need to first fetch it and load it into the `core-data` store. For example, the following code loads the post with ID 1 into the store. (The entity is the post, the post 1 is the entity record).
 
 ````js
-wp.data.dispatch( 'core' ).getEntityRecord( 'postType', 'post', 1 );
+wp.data.select( 'core' ).getEntityRecord( 'postType', 'post', 1 );
 ````
 
 Once the entity is loaded, you can edit it. For example, the following code sets the title of the post to "Hello World". For each fetched entity record, the `core-data` store keeps track of:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update docs by using the selector instead dispatch while getting POST information from the store

## Why?
Ensuring the docs reflect our selector's behavior

## Testing Instructions
Ensure the following docs https://developer.wordpress.org/block-editor/explanations/architecture/entities/ uses `wp.data.select( 'core' ).getEntityRecord( 'postType', 'post', 1 );` instead of `wp.data.dispatch( 'core' ).getEntityRecord( 'postType', 'post', 1 );`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
